### PR TITLE
fix: change redist.url to redis.host to avoid bug, and also not acces…

### DIFF
--- a/openmusic-api/src/services/CacheService.js
+++ b/openmusic-api/src/services/CacheService.js
@@ -4,7 +4,7 @@ const { config } = require("../utils");
 class CacheService {
   constructor() {
     this._client = redis.createClient({
-      url: `redis://${config.redis.host}:6379`,
+      host: config.redis.host,
     });
 
     this._client.on("error", (error) => console.error(`Redis error, ${error}`));


### PR DESCRIPTION
…s directly to .env but with config.js to access env variables at CacheService.js